### PR TITLE
Fix typos - Ejemplo 7 Reto 5

### DIFF
--- a/Sesion-01/Ejemplo-07/estructuras_de_control_de_flujo.ipynb
+++ b/Sesion-01/Ejemplo-07/estructuras_de_control_de_flujo.ipynb
@@ -73,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hay veces que queremos tener una acción `default`, que queremos que suceda es caso de que la comparación sea `False`. Para eso podemos usar una sentencia `else`. Piénsalo como preguntarse a uno mismo: \"Si meto mi mano a la bolsa y resulta que encuentro un billete de $50, me compro unos nachos; si no hay nada, veré la película llorando de tristeza\".\n",
+    "Hay veces que queremos tener una acción `default`, que queremos que suceda en caso de que la comparación sea `False`. Para eso podemos usar una sentencia `else`. Piénsalo como preguntarse a uno mismo: \"Si meto mi mano a la bolsa y resulta que encuentro un billete de $50, me compro unos nachos; si no hay nada, veré la película llorando de tristeza\".\n",
     "\n",
     "Implementamos la acción `default` así:"
    ]

--- a/Sesion-01/Readme.md
+++ b/Sesion-01/Readme.md
@@ -113,7 +113,7 @@ Veamos cómo funcionan.
 
 <ins>Estructuras de control de flujo</ins>
 
-Para finalizar, vamos a juntar todo lo que hemos aprendido el día de hoy y vamos a darle a nuestro programa la capacidad de tomar decisiones. Los programas tienen datos de entrada (inputs) y datos de salida (outputs). Varían sus outputs dependiendo del input que obtengan. Para poder tomar decisiones, utilizan las llamadas `estructuras de control de flujo`. Que se ven así:
+Para finalizar, vamos a juntar todo lo que hemos aprendido el día de hoy y vamos a darle a nuestro programa la capacidad de tomar decisiones. Los programas tienen datos de entrada (inputs) y datos de salida (outputs). Varían sus outputs dependiendo del input que reciban. Para poder tomar decisiones, utilizan las llamadas `estructuras de control de flujo`. Que se ven así:
 
 ```
 if var_1 > var_2:

--- a/Sesion-01/Reto-05/estructuras_de_control_de_flujo.ipynb
+++ b/Sesion-01/Reto-05/estructuras_de_control_de_flujo.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "Escribe tu estructura de control y, por ahora (más adelante tendremos más herramientas para hacer esto más interesante) imprime una string que diga de cuánto va a ser el bono.\n",
     "\n",
-    "> Reto opcional: Agrega una variable `sueldo` que sea el sueldo de tu empleado y agrégale el porcentaje de bono a esa variable dependiendo de la condición que se cumpla. Después hasta el final imprime una string interpolada que diga algo como \"Felicidades, tu sueldo es x; tu bono es de x; y el total de sueldo con el bono incluido es de x\". !Para que esto funcione también debes de agregar una variable donde guardes la cantidad del bono!"
+    "> Reto opcional: Agrega una variable `sueldo` que sea el sueldo de tu empleado y agrégale el porcentaje de bono a esa variable dependiendo de la condición que se cumpla. Después hasta el final imprime una string interpolada que diga algo como \"Felicidades, tu sueldo es x; tu bono es de x; y el total de sueldo con el bono incluido es de x\". ¡Para que esto funcione también debes de agregar una variable donde guardes la cantidad del bono!"
    ]
   },
   {


### PR DESCRIPTION
- Corregí un typo en el ejemplo 7:  es -> en
- Cambié "input que obtengan" por "input que reciban" en el readme general
- Volteé un signo de admiración que estaba al revés en el reto