### PR TITLE
Arreglar llave inexistente y corregir error de sintaxis

### DIFF
--- a/Sesion-02/Readme.md
+++ b/Sesion-02/Readme.md
@@ -46,7 +46,7 @@ Veámoslos en acción.
 
 <ins>Creando y accesando diccionarios</ins>
 
-Los diccionarios son nuestra segunda estructura de datos básica en Python. A diferencia de las listas, los diccionarios no tienen un orden definido. Esto no importa demasiado porque los diccionarios contienen pares llave-valor en vez de elementos (como en las listas). Para acceder a los valores basta con pasarle al diccionario la llave que estamos buscando. Piénsalo como pasarle un `url` a tu navegador para obtener una página web. En algún lado hay una estructura similar a un diccionario que relaciona cada `url` con el ip en donde está almacenada la página a la queremos acceder.
+Los diccionarios son nuestra segunda estructura de datos básica en Python. A diferencia de las listas, los diccionarios no tienen un orden definido. Esto no importa demasiado porque los diccionarios contienen pares llave-valor en vez de elementos (como en las listas). Para acceder a los valores basta con pasarle al diccionario la llave que estamos buscando. Piénsalo como pasarle un `url` a tu navegador para obtener una página web. En algún lado hay una estructura similar a un diccionario que relaciona cada `url` con la ip en donde está almacenada la página a la queremos acceder.
 
 Veamos cómo crear y acceder diccionarios.
 

--- a/Sesion-02/Reto-03/diccionarios.ipynb
+++ b/Sesion-02/Reto-03/diccionarios.ipynb
@@ -52,13 +52,13 @@
     "ganancias_totales = ventas_mensuales[\"ganancias_pasteleria\"] + ventas_mensuales[\"ganancias_panaderia\"]\n",
     "ganancias_netas = ganancias_totales - ventas_mensuales[\"gastos_mensuales_totales\"]\n",
     "\n",
-    "print(f'==Resumen de ventas mensuales de la unidad {ventas_mensuales[\"Aragón\"]}==/n')\n",
+    "print(f'==Resumen de ventas mensuales de la unidad {ventas_mensuales[\"unidad\"]}==/n')\n",
     "print(f'Fecha de corte: {ventas_mensuales[\"fecha_de_corte\"]}/n')\n",
     "print(f'  - Ventas totales de insumos: {ventas_totales_de_insumos}')\n",
     "print(f'  - Ganancias totales: {ganancias_totales}')\n",
     "print(f'  - Ganancias netas: {ganancias_netas}')\n",
     "print(f'\\n')\n",
-    "print(f'(Información recabada por: {ventas_mensuales['analista']})')"
+    "print(f'(Información recabada por: {ventas_mensuales[\"analista\"]})')"
    ]
   },
   {


### PR DESCRIPTION
En el reto 3 de la sesión 2 había dos errores. No sé si eran intencionales, pero los corregí:

1. Se accesaba al diccionario por su valor en lugar de la llave: "Aragón" -> "unidad".
2. Al accesar a la llave *analista* se usaban comillas simples, y como en la f-string también eran simples fallaba con error de sintaxis.

También en el readme general cambié 'el ip' por 'la ip'.