### PR TITLE
Errores de redaccion y typos

### DIFF
--- a/Sesion-03/Ejemplo-02/filter.ipynb
+++ b/Sesion-03/Ejemplo-02/filter.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Como nuestra función regresa `True` si el valor es par, nuestra `lista` es resultante sòlo tiene valores pares.\n",
+    "Como nuestra función regresa `True` si el valor es par, nuestra `lista` resultante sólo tiene valores pares.\n",
     "\n",
     "Veamos otro ejemplo:"
    ]

--- a/Sesion-03/Readme.md
+++ b/Sesion-03/Readme.md
@@ -42,9 +42,9 @@ Veamos cómo funciona.
 
 <ins>`filter`</ins>
 
-Nuestra segunda función se llama `filter`. Tal y como su nombre lo dice, `filter` nos ayuda a filtrar elementos de la lista que no queremos.
+Nuestra segunda función se llama `filter`. Tal y como su nombre lo dice, `filter` nos ayuda a filtrar elementos que no queremos de la lista.
 
-`filter` recibe una función que regrese `True` o `False` y una `lista`. Despuès aplica la función "elemento por elemento" a la `lista`. Cada vez que la función regrese `True`, el elemento se queda en la nueva lista; cuando la función regrese `False`, el elemento es descartado:
+`filter` recibe una función que regrese `True` o `False` y una `lista`. Después aplica la función "elemento por elemento" a la `lista`. Cada vez que la función regrese `True`, el elemento se queda en la nueva lista; cuando la función regrese `False`, el elemento es descartado:
 
 <div style="padding: 10px; margin: 20px"><img src='./Imgs/sesion-3_44.png'></div>
 


### PR DESCRIPTION
Modifiqué un acento al revés y un "es" que estaba de más en el ejemplo 2 del reto 3.

También en la descripción de esa sección había un acento al revés y cambié ligeramente el propósito de *filter* para que se entendiera mejor.