### PR TITLE
Typos y errores de redacción

### DIFF
--- a/Sesion-04/Ejemplo-02/series.ipynb
+++ b/Sesion-04/Ejemplo-02/series.ipynb
@@ -7,7 +7,7 @@
     "## Ejemplo 2: Series\n",
     "\n",
     "### 1. Objetivos:\n",
-    "    - Entender que son las `Series`\n",
+    "    - Entender qué son las `Series`\n",
     "    - Aprender a crear `Series` de pandas\n",
     "    - Aprender los métodos básicos de indexación de las `Series`\n",
     " \n",
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Una gran diferencia que tienen con las `listas` es que cada elemento en una `Serie` tiene un índice asociado que no necesariamente es una secuencia de íntegros como en las `listas`. En este aspecto, nuestras `Series` se parecen a los `diccionarios`:"
+    "Una gran diferencia que tienen con las `listas` es que cada elemento en una `Serie` tiene un índice asociado que no necesariamente es una secuencia de enteros como en las `listas`. En este aspecto, nuestras `Series` se parecen a los `diccionarios`:"
    ]
   },
   {
@@ -85,7 +85,7 @@
     "3. `bool`: Equivalente a `bool` (duh)\n",
     "4. `object`: Equivalente a `str`, o indica que hay una mezcla de tipos de datos numéricos y no-numéricos en la `Serie`\n",
     "\n",
-    "> **Importante**: Tener `Series` que contengan diversos de tipos de datos es una **muy mala** práctica. Lo recomendable es siempre tener homogeneidad de tipos de dato en cada `Serie` que tengamos. De todas maneras, se encontrarán por ahí algunos conjuntos de datos que contienen `Series` con tipos de datos diversos. Es por eso que cuando nos topemos con un tipo de dato `obj` tenemos que ser cuidadosos y no asumir automáticamente que el tipo de dato incluido son `strings`."
+    "> **Importante**: Tener `Series` que contengan diversos tipos de datos es una **muy mala** práctica. Lo recomendable es siempre tener homogeneidad de tipos de dato en cada `Serie` que tengamos. De todas maneras, se encontrarán por ahí algunos conjuntos de datos que contienen `Series` con tipos de datos diversos. Es por eso que cuando nos topemos con un tipo de dato `obj` tenemos que ser cuidadosos y no asumir automáticamente que el tipo de dato incluido son `strings`."
    ]
   },
   {


### PR DESCRIPTION
Agregué un acento, quité un "de" que sobraba y cambié "secuencia de íntegros" por "secuencias de enteros" para referirme a los índices de una lista.