### PR TITLE
Fix typo

### DIFF
--- a/Sesion-04/Ejemplo-04/dataframes.ipynb
+++ b/Sesion-04/Ejemplo-04/dataframes.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "### 1. Objetivos:\n",
     "    - Aprender a crear `DataFrames` usando diccionarios de listas\n",
-    "    - Aprender a indexar `DataFrames` parar obtener subconjuntos de datos\n",
+    "    - Aprender a indexar `DataFrames` para obtener subconjuntos de datos\n",
     " \n",
     "---\n",
     "    \n",


### PR DESCRIPTION
- Se corrigió un typo en el ejemplo 4 de la sesión 4: "parar obtener" -> "para obtener"