### PR TITLE
Cambiar mappear por mapear y fix typos

### DIFF
--- a/Sesion-07/Ejemplo-02/manipulacion_de_strings.ipynb
+++ b/Sesion-07/Ejemplo-02/manipulacion_de_strings.ipynb
@@ -412,7 +412,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Éste último es más adecuado, vamos a guardarlo:"
+    "Este último es más adecuado, vamos a guardarlo:"
    ]
   },
   {

--- a/Sesion-07/Readme.md
+++ b/Sesion-07/Readme.md
@@ -57,7 +57,7 @@ Para eso tenemos la propiedad `str` que estudiaremos a continuación.
 
 <ins>`map`</ins>
 
-Otra cosa que podemos hacer es usar un mappeo de un dato a otro. Esto significa que le damos a `pandas` algún objeto que contenga una correspondencia entre un dato y otro para que realice una conversión.
+Otra cosa que podemos hacer es usar un mapeo de un dato a otro. Esto significa que le damos a `pandas` algún objeto que contenga una correspondencia entre un dato y otro para que realice una conversión.
 
 `map` nos permite pasarle tanto un `diccionario` como una `función` para realizar la conversión de un dato a otro.
 

--- a/Sesion-07/Reto-03/map.ipynb
+++ b/Sesion-07/Reto-03/map.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Reto 4: Map\n",
+    "## Reto 3: Map\n",
     "\n",
     "### 1. Objetivos:\n",
-    "    - Practicar el uso del método `map` para mappear un dato a otro dato que le corresponde.\n",
+    "    - Practicar el uso del método `map` para mapear un dato a otro dato que le corresponde.\n",
     "    \n",
     "---\n",
     "    \n",
@@ -22,8 +22,8 @@
     "\n",
     "Vamos a trabajar sobre el dataset que guardaste en el Reto anterior. Esta vez tu Reto es muy sencillo:\n",
     "\n",
-    "1. La columna `is_potentially_hazardous_asteroid` tiene valores `booleanos`. Crea un diccionario de mappeo donde hagas un correspondencia de cada valor `booleano` con su equivalente numérico y transforma esa columna.\n",
-    "2. Usa una función para mappear la columna `relative_velocity.kilometers_per_hour` a una nueva columna llamada `relative_velocity.kilometers_per_minute`, que contenga la velocidad del objeto en kilómetros por minuto.\n",
+    "1. La columna `is_potentially_hazardous_asteroid` tiene valores `booleanos`. Crea un diccionario de mapeo donde hagas un correspondencia de cada valor `booleano` con su equivalente numérico y transforma esa columna.\n",
+    "2. Usa una función para mapear la columna `relative_velocity.kilometers_per_hour` a una nueva columna llamada `relative_velocity.kilometers_per_minute`, que contenga la velocidad del objeto en kilómetros por minuto.\n",
     "3. Guarda tu `DataFrame` resultante en la variable `df_reto_3`.\n",
     "4. Guarda tu resultado en un archivo .csv."
    ]

--- a/Sesion-07/Reto-03/map.ipynb
+++ b/Sesion-07/Reto-03/map.ipynb
@@ -70,6 +70,8 @@
     "df['is_potentially_hazardous_asteroid'] = df['is_potentially_hazardous_asteroid'].map(mapa)\n",
     "def kilometers_per_hour_to_per_minute(value):\n",
     "    return value / 60\n",
+    "    \n",
+    "df['relative_velocity.kilometers_per_hour'] = pd.to_numeric(df['relative_velocity.kilometers_per_hour'], errors='coerce')\n",
     "df['relative_velocity.kilometers_per_minute'] = df['relative_velocity.kilometers_per_hour'].map(kilometers_per_hour_to_per_minute)\n",
     "```\n",
     "    \n",


### PR DESCRIPTION
No pude encontrar el uso de **mappeo** en internet.

Así que basado en este artículo de Wikipedia: https://es.wikipedia.org/wiki/Mapeo_objeto-relacional

Decidí hacer el cambio de mappeo por mapeo.

- También corregí la solución en el reto 3, porque faltaba hacer un coerce para que no tronara.